### PR TITLE
Implement word-break to custom pages and product descriptions

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Netizen",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "images": [
     {
       "variable": "logo",

--- a/source/stylesheets/layout.css.sass
+++ b/source/stylesheets/layout.css.sass
@@ -740,6 +740,8 @@ footer
       width: 100% !important
 
 .custom-page-content, .product-description
+  word-break: break-word
+
   a
     text-decoration: underline
 


### PR DESCRIPTION
Makes sure long URLs (and other long words) don't break the layout and overflow the container. Instead they'll wrap to the next line