### PR TITLE
Netizen v1.10.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -46,14 +46,12 @@
 </div>
 
 {% if cart.items != blank and theme.show_bnpl_messaging and cart.items != blank %}
-  {% unless theme.features.opt_outs contains "theme_bnpl_messaging" %}
-    <div id="payment-processor-messaging">
-      <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
-        <div id="paypal-messaging-element"></div>
-      </div>
-      <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
-        <div id="payment-method-messaging-element"></div>
-      </div>
+  <div id="payment-processor-messaging">
+    <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
+      <div id="paypal-messaging-element"></div>
     </div>
-  {% endunless %}
+    <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
+      <div id="payment-method-messaging-element"></div>
+    </div>
+  </div>
 {% endif %}

--- a/source/home.html
+++ b/source/home.html
@@ -57,7 +57,19 @@
               <div class="product-list-item-info">
                 <div class="product-list-item-info-headers">
                   <div class="product-list-item-name">{{ product.name }}</div>
-                  <div class="product-list-item-price">{{ product.default_price | money: theme.money_format }}</div>
+                  <div class="product-list-item-price">
+                    {% assign hide_price = false %}
+                    {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                      {% assign hide_price = true %}
+                    {% endif -%}
+                    {% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+                      {% assign hide_price = true %}
+                    {% endif %}
+
+                    {% unless hide_price %}
+                      {{ product.default_price | money: theme.money_format }}
+                    {% endunless %}
+                  </div>
                 </div>
               </div>
             </div>

--- a/source/layout.html
+++ b/source/layout.html
@@ -380,7 +380,9 @@
             </ul>
           </nav>
         {% endif %}
-        {{ powered_by_big_cartel }}
+        <div data-bc-hook="credit">
+          {{ powered_by_big_cartel }}
+        </div>
       </div>
       </footer>
     </div>

--- a/source/layout.html
+++ b/source/layout.html
@@ -143,7 +143,7 @@
         </div>
       {% endif %}
       {% if page.permalink == 'home' %}
-        {% if theme.welcome_image != blank or theme.welcome_header != blank or theme.welcome_subheader != blank or theme.welcome_button_text != blank %}
+        {% if theme.welcome_image != blank or theme.welcome_header != blank or theme.welcome_subheader != blank %}
           <section class="home-welcome welcome gradient">
             <div class="welcome-messaging">
               <div class="welcome-header-group">

--- a/source/product.html
+++ b/source/product.html
@@ -67,16 +67,14 @@
 
 </div>
 {% if product.status == "active" and theme.show_bnpl_messaging %}
-  {% unless theme.features.opt_outs contains "theme_bnpl_messaging" %}
-    <div id="payment-processor-messaging">
-      <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
-        <div id="paypal-messaging-element"></div>
-      </div>
-      <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
-        <div id="payment-method-messaging-element"></div>
-      </div>
+  <div id="payment-processor-messaging">
+    <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
+      <div id="paypal-messaging-element"></div>
     </div>
-  {% endunless %}
+    <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
+      <div id="payment-method-messaging-element"></div>
+    </div>
+  </div>
 {% endif %}
 <div class="product-images {% if product.images.size > 1 %}main-carousel{% else %} single-image{% endif %}">
   {% for image in product.images %}

--- a/source/product.html
+++ b/source/product.html
@@ -7,16 +7,26 @@
   {% when 'coming-soon' %}
     {% assign product_status = 'Coming soon' %}
 {% endcase %}
+
+{% assign hide_price = false %}
+{% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+  {% assign hide_price = true %}
+{% endif -%}
+{% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+  {% assign hide_price = true %}
+{% endif %}
 <div class="product-heading">
   <div class="product-titles">
     <h1 class="page-title product-title">{{ product.name }}</h1>
     <div class="product-subtitle">
       {% if product_status != blank %}<span class="product-status">{{ product_status }}</span>{% endif %}
-      {% if product.variable_pricing %}
-        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-      {% else %}
-        {{ product.default_price | money: theme.money_format }}
-      {% endif %}
+      {% unless hide_price %}
+        {% if product.variable_pricing %}
+          {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+        {% else %}
+          {{ product.default_price | money: theme.money_format }}
+        {% endif %}
+      {% endunless %}
     </div>
   </div>
   {% if product.status == 'active' %}

--- a/source/products.html
+++ b/source/products.html
@@ -27,7 +27,19 @@
             <div class="product-list-item-info">
               <div class="product-list-item-info-headers">
                 <div class="product-list-item-name">{{ product.name }}</div>
-                <div class="product-list-item-price">{{ product.default_price | money: theme.money_format }}</div>
+                <div class="product-list-item-price">
+                  {% assign hide_price = false %}
+                  {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% assign hide_price = true %}
+                  {% endif -%}
+                  {% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+                    {% assign hide_price = true %}
+                  {% endif %}
+
+                  {% unless hide_price %}
+                    {{ product.default_price | money: theme.money_format }}
+                  {% endunless %}
+                </div>
               </div>
             </div>
           </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -5,11 +5,13 @@
     {
       "variable": "logo",
       "label": "Header logo",
+      "section": "global_navigation",
       "description": "200x200px image recommended"
     },
     {
       "variable": "welcome_image",
       "label": "Home page welcome image",
+      "section": "homepage",
       "description": "1400x850px image recommended"
 
     }
@@ -18,6 +20,7 @@
     {
       "variable": "lookbook_images",
       "label": "Lookbook",
+      "section": "general",
       "description": "Adds a gallery to the specified Lookbook page"
     }
   ],
@@ -467,48 +470,97 @@
   ],
   "options": [
     {
-      "variable": "maintenance_message",
-      "label": "Maintenance mode message",
+      "variable": "show_search",
+      "label": "Show search",
+      "section": "global_navigation",
+      "type": "boolean",
+      "default": true,
+      "description": "Shows a search field"
+    },
+    {
+      "variable": "product_list_layout",
+      "label": "Product List Layout",
+      "section": "global_navigation",
+      "type": "select",
+      "options": [
+          ["Masonry", "masonry"],
+          ["Rows", "fitRows"]
+      ],
+      "default": "fitRows",
+      "description": "The arrangement of your products on the Home and Products pages"
+    },
+    {
+      "variable": "max_products_per_row",
+      "label": "Maximum products per row",
+      "section": "global_navigation",
+      "type": "select",
+      "options": "1..3",
+      "default": 3,
+      "description": "The maximum number of products displayed per row"
+    },
+    {
+      "variable": "max_products_per_row_mobile",
+      "label": "Maximum products per row (mobile)",
+      "section": "global_navigation",
+      "type": "select",
+      "options": "1..2",
+      "default": 2,
+      "description": "The maximum number of products displayed per row on small screens"
+    },
+    {
+      "variable": "products_per_page",
+      "label": "Products per page",
+      "section": "global_navigation",
+      "type": "select",
+      "options": "1..100",
+      "default": 36,
+      "description": "The number of products shown per page"
+    },
+    {
+      "variable": "show_overlay",
+      "label": "Product list info",
+      "section": "global_navigation",
+      "type": "select",
+      "options": [
+        ["On rollover", "rollover"],
+        ["Under image", "under_image"]
+      ],
+      "default": "under_image",
+      "description": "Shows a product's name & price on hover, or under the image"
+    },
+    {
+      "variable": "footer_text",
+      "label": "Footer text",
+      "section": "global_navigation",
       "type": "text",
       "max_length": 2048,
-      "description": "A message visitors see when your shop is in Maintenance Mode",
-      "default": "We're working on our shop right now.<br /><br />Please check back soon."
-    },
-    {
-      "variable": "announcement_message_text",
-      "label": "Announcement text",
-      "type": "text",
-      "max_length": 500,
-      "description": "Displays an announcement message on the top of every page"
-    },
-    {
-      "variable": "contact_text",
-      "label": "Contact page text",
-      "type": "text",
-      "max_length": 1024,
-      "description": "Displays a message on your contact page"
+      "description": "Show a custom message above your shop's footer"
     },
     {
       "variable": "welcome_header",
       "label": "Welcome header",
+      "section": "homepage",
       "type": "text",
       "description": "Welcome header for Home page"
     },
     {
       "variable": "welcome_subheader",
       "label": "Welcome subheader",
+      "section": "homepage",
       "type": "text",
       "description": "Welcome subheader for Home page"
     },
     {
       "variable": "welcome_button_text",
       "label": "Welcome button",
+      "section": "homepage",
       "type": "text",
       "description": "Welcome button text on Home page that links to the Products page (e.g. 'Shop now')"
     },
     {
       "variable": "welcome_button_behavior",
       "label": "Welcome Button Behavior",
+      "section": "homepage",
       "type": "select",
       "options": [
         ["Scroll down page", "scroll"],
@@ -523,6 +575,7 @@
     {
       "variable": "welcome_image_brightness",
       "label": "Welcome image overlay effect",
+      "section": "homepage",
       "type": "select",
       "options": [
         ["Brightest", "1.75"],
@@ -537,14 +590,9 @@
       "description": "Adjust the home page welcome image overlay to enhance the legibility of welcome header text"
     },
     {
-      "variable": "lookbook_page_name",
-      "label": "Lookbook Page Name",
-      "type": "text",
-      "description": "Create a custom page for your lookbook, then enter the page name in this field"
-    },
-    {
       "variable": "welcome_overlay",
       "label": "Welcome image overlay",
+      "section": "homepage",
       "type": "select",
       "options": [
         ["None", ""],
@@ -558,35 +606,9 @@
       "description": "Style of the overlay that sits on top of your welcome image"
     },
     {
-      "variable": "product_list_layout",
-      "label": "Product List Layout",
-      "type": "select",
-      "options": [
-          ["Masonry", "masonry"],
-          ["Rows", "fitRows"]
-      ],
-      "default": "fitRows",
-      "description": "The arrangement of your products on the Home and Products pages"
-    },
-    {
-      "variable": "max_products_per_row",
-      "label": "Maximum products per row",
-      "type": "select",
-      "options": "1..3",
-      "default": 3,
-      "description": "The maximum number of products displayed per row"
-    },
-    {
-      "variable": "max_products_per_row_mobile",
-      "label": "Maximum products per row (mobile)",
-      "type": "select",
-      "options": "1..2",
-      "default": 2,
-      "description": "The maximum number of products displayed per row on small screens"
-    },
-    {
       "variable": "featured_header",
       "label": "Featured products header",
+      "section": "homepage",
       "type": "text",
       "description": "Displays above featured products on the Home page",
       "default": "Featured Products"
@@ -594,6 +616,7 @@
     {
       "variable": "featured_products",
       "label": "Featured products",
+      "section": "homepage",
       "type": "select",
       "options": "0..48",
       "default": 12,
@@ -602,6 +625,7 @@
     {
       "variable": "featured_order",
       "label": "Featured products order",
+      "section": "homepage",
       "type": "select",
       "options": "product_orders",
       "default": "position",
@@ -610,21 +634,15 @@
     {
       "variable": "all_products_button_text",
       "label": "All products button text",
+      "section": "homepage",
       "type": "text",
       "description": "Displays underneath featured products and links to your Products Page",
       "default": "All Products"
     },
     {
-      "variable": "products_per_page",
-      "label": "Products per page",
-      "type": "select",
-      "options": "1..100",
-      "default": 36,
-      "description": "The number of products shown per page"
-    },
-    {
       "variable": "featured_categories",
       "label": "Featured categories on Home page",
+      "section": "homepage",
       "type": "select",
       "options": "0..20",
       "default": 3,
@@ -633,6 +651,7 @@
     {
       "variable": "featured_categories_header",
       "label": "Featured categories header",
+      "section": "homepage",
       "type": "text",
       "default": "Featured Categories",
       "description": "Displays above featured categories on the Home page",
@@ -643,6 +662,7 @@
     {
       "variable": "featured_categories_position",
       "label": "Featured categories position",
+      "section": "homepage",
       "type": "select",
       "options": [
         ["Top", "top"],
@@ -657,6 +677,7 @@
     {
       "variable": "featured_category_button_text",
       "label": "Button text featured categories on Home page",
+      "section": "homepage",
       "type": "text",
       "default": "Shop",
       "description": "Button text for featured categories on the Home page",
@@ -665,26 +686,9 @@
       ]
     },
     {
-      "variable": "show_overlay",
-      "label": "Product list info",
-      "type": "select",
-      "options": [
-        ["On rollover", "rollover"],
-        ["Under image", "under_image"]
-      ],
-      "default": "under_image",
-      "description": "Shows a product's name & price on hover, or under the image"
-    },
-    {
-      "variable": "show_search",
-      "label": "Show search",
-      "type": "boolean",
-      "default": true,
-      "description": "Shows a search field"
-    },
-    {
       "variable": "show_similar_products",
       "label": "Show related products",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Displays related products on the Product page"
@@ -692,6 +696,7 @@
     {
       "variable": "related_products_header",
       "label": "Related products header",
+      "section": "product_page",
       "type": "text",
       "description": "Displays above related products on Products pages",
       "default": "You might also like",
@@ -702,6 +707,7 @@
     {
       "variable": "related_products",
       "label": "Related products",
+      "section": "product_page",
       "type": "select",
       "options": "1..9",
       "default": 3,
@@ -713,6 +719,7 @@
     {
       "variable": "related_products_order",
       "label": "Related products order",
+      "section": "product_page",
       "type": "select",
       "options": "product_orders",
       "default": "top-selling",
@@ -724,6 +731,7 @@
     {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product options",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Shows sold out product options in the Product page dropdowns",
@@ -732,25 +740,9 @@
       ]
     },
     {
-      "variable": "show_sold_out_product_prices",
-      "label": "Show prices for sold out products",
-      "type": "boolean",
-      "default": true,
-      "description": "Show the price of sold out products on product grids and product pages",
-      "requires": [
-        "inventory"
-      ]
-    },
-    {
-      "variable": "show_coming_soon_product_prices",
-      "label": "Show prices for coming soon products",
-      "type": "boolean",
-      "default": true,
-      "description": "Show the price of coming soon products on product grids and product pages"
-    },
-    {
       "variable": "show_low_inventory_messages",
       "label": "Show product stock alerts",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Show shoppers alerts on Product pages when it's running low on stock",
@@ -761,6 +753,7 @@
     {
       "variable": "low_inventory_threshold",
       "label": "Low stock alert",
+      "section": "product_page",
       "options": "1..100",
       "type": "select",
       "default": "10",
@@ -773,6 +766,7 @@
     {
       "variable": "low_inventory_message",
       "label": "Low stock message",
+      "section": "product_page",
       "type": "text",
       "max_length": 50,
       "description": "Message shown when stock drops below your alert level",
@@ -785,6 +779,7 @@
     {
       "variable": "almost_sold_out_message",
       "label": "Almost sold out message",
+      "section": "product_page",
       "type": "text",
       "max_length": 50,
       "description": "Message shown when stock drops below half your alert level",
@@ -796,15 +791,9 @@
       ]
     },
     {
-      "variable": "footer_text",
-      "label": "Footer text",
-      "type": "text",
-      "max_length": 2048,
-      "description": "Show a custom message above your shop's footer"
-    },
-    {
       "variable": "show_bnpl_messaging",
       "label": "Buy Now, Pay Later Messaging",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
@@ -813,8 +802,35 @@
       ]
     },
     {
+      "variable": "lookbook_page_name",
+      "label": "Lookbook Page Name",
+      "section": "general",
+      "type": "text",
+      "description": "Create a custom page for your lookbook, then enter the page name in this field"
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "section": "general",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of sold out products on product grids and product pages",
+      "requires": [
+        "inventory"
+      ]
+    },
+    {
+      "variable": "show_coming_soon_product_prices",
+      "label": "Show prices for coming soon products",
+      "section": "general",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of coming soon products on product grids and product pages"
+    },
+    {
       "variable": "money_format",
       "label": "Price display",
+      "section": "general",
       "type": "select",
       "options": [
         ["Currency sign", "sign"],
@@ -824,86 +840,125 @@
       "description": "Sets the display of prices in your shop"
     },
     {
+      "variable": "maintenance_message",
+      "label": "Maintenance mode message",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 2048,
+      "description": "A message visitors see when your shop is in Maintenance Mode",
+      "default": "We're working on our shop right now.<br /><br />Please check back soon."
+    },
+    {
+      "variable": "announcement_message_text",
+      "label": "Announcement text",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 500,
+      "description": "Displays an announcement message on the top of every page"
+    },
+    {
+      "variable": "contact_text",
+      "label": "Contact page text",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 1024,
+      "description": "Displays a message on your contact page"
+    },
+    {
       "variable": "instagram_url",
       "label": "Instagram URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://instagram.com/bigcartel"
     },
     {
       "variable": "tiktok_url",
       "label": "TikTok URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://tiktok.com/@bigcartelofficial"
     },
     {
       "variable": "bluesky_url",
       "label": "Bluesky URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bsky.app/profile/bigcartel.com"
     },
     {
       "variable": "threads_url",
       "label": "Threads URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://threads.net/@bigcartel"
     },
     {
       "variable": "twitter_url",
       "label": "X URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://x.com/bigcartel"
     },
     {
       "variable": "facebook_url",
       "label": "Facebook URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://facebook.com/bigcartel"
     },
     {
       "variable": "snapchat_url",
       "label": "Snapchat URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://snapchat.com/add/bigcartel"
     },
     {
       "variable": "pinterest_url",
       "label": "Pinterest URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://pinterest.com/big_cartel"
     },
     {
       "variable": "youtube_url",
       "label": "YouTube URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://youtube.com/@BigCartelDotCom"
     },
     {
       "variable": "spotify_url",
       "label": "Spotify URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://open.spotify.com/artist/0gxy..."
     },
     {
       "variable": "linkedin_url",
       "label": "LinkedIn URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://linkedin.com/in/bigcartel"
     },
     {
       "variable": "twitch_url",
       "label": "Twitch URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://twitch.tv/username"
     },
     {
       "variable": "tumblr_url",
       "label": "Tumblr URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bigcartel.tumblr.com"
     },
     {
       "variable": "bandcamp_url",
       "label": "Bandcamp URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bigcartel.bandcamp.com"
     }

--- a/source/settings.json
+++ b/source/settings.json
@@ -595,7 +595,7 @@
       "variable": "featured_products",
       "label": "Featured products",
       "type": "select",
-      "options": "0..100",
+      "options": "0..48",
       "default": 12,
       "description": "The number of products featured on the Home page"
     },
@@ -730,6 +730,23 @@
       "requires": [
         "inventory"
       ]
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of sold out products on product grids and product pages",
+      "requires": [
+        "inventory"
+      ]
+    },
+    {
+      "variable": "show_coming_soon_product_prices",
+      "label": "Show prices for coming soon products",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of coming soon products on product grids and product pages"
     },
     {
       "variable": "show_low_inventory_messages",

--- a/source/settings.json
+++ b/source/settings.json
@@ -798,7 +798,7 @@
       "default": true,
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
       "requires": [
-        "feature:theme_bnpl_messaging neq opted_out"
+        "feature:theme_bnpl_messaging eq visible"
       ],
       "plan_type": "paid"
     },

--- a/source/settings.json
+++ b/source/settings.json
@@ -799,7 +799,8 @@
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
       "requires": [
         "feature:theme_bnpl_messaging neq opted_out"
-      ]
+      ],
+      "plan_type": "paid"
     },
     {
       "variable": "lookbook_page_name",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Netizen",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Netizen",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -790,7 +790,10 @@
       "label": "Buy Now, Pay Later Messaging",
       "type": "boolean",
       "default": true,
-      "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan."
+      "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
+      "requires": [
+        "feature:theme_bnpl_messaging neq opted_out"
+      ]
     },
     {
       "variable": "money_format",

--- a/source/stylesheets/layout.css.sass
+++ b/source/stylesheets/layout.css.sass
@@ -747,7 +747,7 @@ footer
         align-items: center
         gap: 8px
         outline-offset: 4px
-        padding: 2px 0
+        padding: 20px 0 2px
         text-decoration: none
 
         &:hover, &:focus


### PR DESCRIPTION
- feat: setting to hide coming soon products
- fix: don't show header if just the welcome button text set
- chore: remove unnecessary bnpl feature flag check 
- chore: bnpl messaging setting respects feature flag
- chore: add `data-bc-hook` to credit
- chore: add `section` props to all theme settings options and order
- chore: add `plan_type` prop to bnpl setting for future use
- chore: use new feature flag format for visibility