### PR TITLE
Netizen 1.12.1

### DIFF
--- a/source/javascripts/product-payment-messaging.js
+++ b/source/javascripts/product-payment-messaging.js
@@ -141,6 +141,23 @@ function getStripeTextColors(backgroundColor) {
 }
 
 /**
+ * Gets the appropriate background color for Stripe elements
+ * @param {string} backgroundColor - Background color in hex
+ * @returns {string} Background color in hex
+ */
+function getStripeBackgroundColors(backgroundColor) {
+  const luminance = calculateLuminance(backgroundColor);
+  const isLightBackground = luminance > 0.5;
+
+  // Use standard colors with PayPal for consistency
+  if (isPaypalPresent()) {
+    return isLightBackground ? '#FFFFFF' : '#000000';
+  } else {
+    return backgroundColor || PAYMENT_CONFIG.DEFAULT_COLORS.background;
+  }
+}
+
+/**
  * Gets Stripe appearance options with configurable text alignment
  * @param {string} backgroundColor - Background color in hex
  * @param {string} alignment - Text alignment value ('left', 'center', 'right')
@@ -156,6 +173,7 @@ function getStripeAppearanceOptions(backgroundColor, alignment = 'left') {
     appearance: {
       variables: {
         colorText: getStripeTextColors(backgroundColor),
+        colorBackground: getStripeBackgroundColors(backgroundColor),
         logoColor: getTextColorMode(backgroundColor, 'stripe'),
         fontFamily,
         fontSizeBase: '16px',

--- a/source/layout.html
+++ b/source/layout.html
@@ -131,7 +131,7 @@
               <div class="emoji-container">
                 <img class="ghost-emoji" src="{{ 'ghost-emoji.png' | theme_image_url }}" alt="Ghost Emoji" aria-hidden="true">
               </div>
-              <strong>Your cart is empty!</strong>
+              <strong>{{ t['cart.empty_cart'] }}</strong>
               <a class="button" href="/">{{ t['cart.continue_shopping'] }}</a>
             </div>
           </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Netizen",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "images": [
     {
       "variable": "logo",


### PR DESCRIPTION
- fix: product page BNPL messaging correctly sets background color for stripe popup
- fix: empty cart messaging uses translations