### PR TITLE
Netizen 1.13.1

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Netizen",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1312,6 +1312,26 @@
       "requires": [ "translation_mode eq manual" ]
     },
     {
+      "variable": "products_product_tr_text",
+      "label": "'Product'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Product",
+      "description": "Text displayed when referencing a single item in your shop",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_products_tr_text",
+      "label": "'Products'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Products",
+      "description": "Text displayed when referencing multiple items in your shop",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
       "variable": "products_related_products_tr_text",
       "label": "Related products header",
       "section": "translations",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1214,7 +1214,7 @@
       "section": "translations",
       "sub_section": "homepage",
       "type": "text",
-      "default": "Featured categories",
+      "default": "Shop by Category",
       "allow_blank": true,
       "description": "Text for the featured categories section on the home page.",
       "requires": [ "translation_mode eq manual" ]

--- a/source/settings.json
+++ b/source/settings.json
@@ -839,7 +839,8 @@
       "label": "Show product variant count in product grids",
       "section": "product_page",
       "type": "boolean",
-      "default": false,
+      "default": true,
+      "upgrade_default": false,
       "description": "For products with multiple variants, show the variant count in product grids."
     },
     {


### PR DESCRIPTION
- chore: variant count in product grids default on only for new themes
- chore: featured categories default text
- chore: product(s) labels translations