### PR TITLE
Netizen v1.15.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -32,7 +32,18 @@
               <button title="+1 {{ item.product.name | escape }}" class="increase-qty-button qty-button" data-func="plus" type="button"><svg fill="currentColor" width="30" height="30" xmlns="http://www.w3.org/2000/svg"><path d="M22.742 14.637v.726c0 .4-.327.726-.726.726H16.09v5.927c0 .4-.327.726-.726.726h-.726a.728.728 0 0 1-.726-.726V16.09H7.984a.728.728 0 0 1-.726-.726v-.726c0-.4.327-.726.726-.726h5.927V7.984c0-.4.327-.726.726-.726h.726c.4 0 .726.327.726.726v5.927h5.927c.4 0 .726.327.726.726zM30 15c0 8.286-6.714 15-15 15S0 23.286 0 15 6.714 0 15 0s15 6.714 15 15zm-1.935 0c0-7.252-5.886-13.065-13.065-13.065C7.748 1.935 1.935 7.821 1.935 15c0 7.252 5.886 13.065 13.065 13.065 7.252 0 13.065-5.886 13.065-13.065z"/></svg></button>
             </div>
             <div class="cart-item-details-price subheader">
-              <span class="cart-item-details-price__update" data-item-id="{{ item.id }}">{{ item.unit_price | money: theme.money_format }}</span>
+              <span class="cart-item-details-price__update" data-item-id="{{ item.id }}">
+                {% assign show_strikethrough = false %}
+                {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                  {% assign show_strikethrough = true %}
+                {% endif %}
+                {% if show_strikethrough %}
+                  <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                  <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                {% else %}
+                  {{ item.unit_price | money: theme.money_format }}
+                {% endif %}
+              </span>
 
               {% if item.product.price_suffix != blank %}
                 <span class="price-suffix">{{ item.product.price_suffix }}</span>

--- a/source/home.html
+++ b/source/home.html
@@ -138,7 +138,7 @@
                   {% unless hide_price %}
                     {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                       <div class="product-list-thumb-options-description">
-                        {{ product.options.size }} {{ t['products.variants'] }}
+                        {{ product.options.size }} {{ t['products.variants'] | downcase }}
                       </div>
                     {% endif %}
                   {% endunless %}

--- a/source/home.html
+++ b/source/home.html
@@ -116,9 +116,36 @@
                     {% endif %}
 
                     {% unless hide_price %}
-                      <span class="price-amount">
-                        {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
-                      </span>
+                      {% assign show_strikethrough = false %}
+                      {% assign strikethrough_regular = nil %}
+                      {% assign strikethrough_sale = nil %}
+
+                      {% if theme.show_strikethrough_pricing %}
+                        {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.original_price %}
+                          {% assign strikethrough_sale = product.default_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.min_original_price %}
+                          {% assign strikethrough_sale = product.min_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.max_original_price %}
+                          {% assign strikethrough_sale = product.max_price %}
+                        {% endif %}
+                      {% endif %}
+
+                      {% if show_strikethrough %}
+                        <span class="price-amount">
+                          <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                          <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                        </span>
+                      {% else %}
+                        <span class="price-amount">
+                          {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                        </span>
+                      {% endif %}
 
                       {% if product.price_suffix != blank %}
                         {% assign variable_price_shown = true %}

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -306,7 +306,7 @@ function processAvailableDropdownOptions(product, changed_dropdown) {
     if (product_option) {
       if (!product_option.sold_out && product_option.id > 0) {
         $('#option').val(product_option.id);
-        enableAddButton(product_option.price);
+        enableAddButton(product_option.price, product_option.original_price);
         if (num_option_groups > 1) {
           $('.reset-selection-button').fadeIn('fast');
         }

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -1,0 +1,167 @@
+$('.product_option_select').on('change',function() {
+  var option_price = $(this).find("option:selected").attr("data-price");
+  var original_price = $(this).find("option:selected").attr("data-original-price");
+  enableAddButton(option_price, original_price);
+});
+
+function updateInventoryMessage(optionId = null) {
+  const product = window.bigcartel?.product;
+  const messageElement = document.querySelector('[data-inventory-message]');
+
+  if (
+    !themeOptions?.showLowInventoryMessages ||
+    !messageElement
+  ) {
+    return;
+  }
+
+  // Guard against race condition - product data may not be loaded yet
+  if (!product) {
+    return;
+  }
+
+  messageElement.textContent = '';
+  const productOptions = product?.options || [];
+
+  // If no option is selected (initial page load or reset) or product has no options
+  if (!optionId) {
+    const hasOptionWithStatus = (status) =>
+      productOptions.length > 0 &&
+      productOptions.some(option =>
+        option &&
+        !option.sold_out &&
+        option[status]
+      );
+
+    // Single option product - check both statuses
+    if (productOptions.length === 1) {
+      const option = productOptions[0];
+      if (option && !option.sold_out) {
+        if (option.isAlmostSoldOut) {
+          messageElement.textContent = themeOptions.almostSoldOutMessage;
+        } else if (option.isLowInventory) {
+          messageElement.textContent = themeOptions.lowInventoryMessage;
+        }
+      }
+      return;
+    }
+
+    // Multiple options - only check for low inventory across all options
+    if (productOptions.length > 1 && hasOptionWithStatus('isLowInventory')) {
+      messageElement.textContent = themeOptions.lowInventoryMessage;
+    }
+    return;
+  }
+
+  // Handle selected option
+  const selectedOption = product.options.find(option => option.id === parseInt(optionId));
+  if (!selectedOption || selectedOption.sold_out) return;
+
+  // For selected options:
+  // - Single option products: check both almost sold out and low inventory
+  // - Multiple option products: check both statuses when specific option selected
+  if (selectedOption.isAlmostSoldOut) {
+    messageElement.textContent = themeOptions.almostSoldOutMessage;
+  } else if (selectedOption.isLowInventory) {
+    messageElement.textContent = themeOptions.lowInventoryMessage;
+  }
+}
+
+function updateProductPrice(updated_price, original_price) {
+  var priceContainer = $('.product-price-value');
+  if (!priceContainer.length || !updated_price) return;
+
+  var updatedNum = parseFloat(updated_price) || 0;
+  var originalNum = parseFloat(original_price) || 0;
+
+  var showStrikethrough = originalNum > updatedNum && themeOptions.showStrikethroughPricing;
+
+  var priceHtml;
+  if (showStrikethrough) {
+    var regularFormatted = formatMoney(original_price, true, true);
+    var saleFormatted = formatMoney(updated_price, true, true);
+    priceHtml = '<s class="price-compare">' + regularFormatted + '</s> <span class="price-sale">' + saleFormatted + '</span>';
+  } else {
+    priceHtml = formatMoney(updated_price, true, true);
+  }
+
+  priceContainer.html(priceHtml);
+}
+
+function enableAddButton(updated_price, original_price) {
+  var addButton = $('.add-to-cart-button');
+  var addButtonTitle = addButton.attr('data-add-title');
+  addButton.attr("disabled",false);
+  // Only hide top border for single option case (not when product_option_groups exists)
+  if ($('.product_option_groups').length === 0) {
+    addButton.css("border-top-width","0");
+  } else {
+    addButton.css("border-top-width","");
+  }
+  addButton.html(addButtonTitle);
+  addButton.attr('aria-label', addButtonTitle);
+  updateInventoryMessage($('#option').val());
+  updateProductPrice(updated_price, original_price);
+  showBnplMessaging(updated_price, { alignment: 'center', displayMode: 'flex', pageType: 'product' });
+}
+
+function disableAddButton(type) {
+  var addButton = $('.add-to-cart-button');
+  var addButtonTitle = addButton.attr('data-add-title');
+  if (type == "sold-out") {
+    var addButtonTitle = addButton.attr('data-sold-title');
+  }
+  if (!addButton.is(":disabled")) {
+    addButton.attr("disabled","disabled");
+  }
+  addButton.html(addButtonTitle);
+  addButton.attr('aria-label','');
+}
+
+function enableSelectOption(select_option) {
+  select_option.removeAttr("disabled");
+  select_option.text(select_option.attr("data-name"));
+  select_option.removeAttr("disabled-type");
+  if ((select_option.parent().is('span'))) {
+    select_option.unwrap();
+  }
+}
+
+function disableSelectOption(select_option, type) {
+  if (type === "sold-out") {
+    disabled_text = select_option.parent().attr("data-sold-text");
+    disabled_type = "sold-out";
+    if (themeOptions.showSoldOutOptions === false) {
+      hide_option = true;
+    }
+    else {
+      hide_option = false;
+    }
+  }
+  if (type === "unavailable") {
+    disabled_text = select_option.parent().attr("data-unavailable-text");
+    disabled_type = "unavailable";
+    hide_option = true;
+  }
+  if (select_option.val() > 0) {
+    var name = select_option.attr("data-name");
+    select_option.attr("disabled",true);
+    select_option.text(name + ' ' + disabled_text);
+    select_option.attr("disabled-type",disabled_type);
+    if (hide_option === true) {
+      if (!(select_option.parent().is('span'))) {
+        select_option.wrap('<span>');
+      }
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const isProductPage = document.body.getAttribute('data-bc-page-type') === 'product';
+  if (isProductPage) {
+    updateInventoryMessage();
+
+    const price = window.bigcartel?.product?.default_price || null;
+    showBnplMessaging(price, { alignment: 'center', displayMode: 'flex', pageType: 'product' });
+  }
+});

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -69,7 +69,18 @@ function updateInventoryMessage(optionId = null) {
 
 function updateProductPrice(updated_price, original_price) {
   var priceContainer = $('.product-price-value');
-  if (!priceContainer.length || !updated_price) return;
+  if (!priceContainer.length) return;
+
+  if (!updated_price) {
+    if (priceContainer.data('original-html') !== undefined) {
+      priceContainer.html(priceContainer.data('original-html'));
+    }
+    return;
+  }
+
+  if (priceContainer.data('original-html') === undefined) {
+    priceContainer.data('original-html', priceContainer.html());
+  }
 
   var updatedNum = parseFloat(updated_price) || 0;
   var originalNum = parseFloat(original_price) || 0;

--- a/source/javascripts/store.js
+++ b/source/javascripts/store.js
@@ -211,11 +211,14 @@ var processUpdate = function(input, item_id, new_val, cart) {
   if (new_val > 0) {
     for (var itemIndex = 0; itemIndex < cart.items.length; itemIndex++) {
       if (cart.items[itemIndex].id == item_id) {
-        var item_price = cart.items[itemIndex].price;
-        var formatted_item_price = formatMoney(item_price, true, true);
+        var item = cart.items[itemIndex];
+        var item_price = item.price;
         var priceElement = document.querySelector('.cart-item-details-price__update[data-item-id="'+item_id+'"]');
+
+        // Line total only shows sale price (no strikethrough - strikethrough is on unit price only)
+        var formattedPrice = formatMoney(item_price, true, true);
         if (priceElement) {
-          priceElement.innerHTML = formatted_item_price;
+          priceElement.innerHTML = formattedPrice;
         }
       }
     }

--- a/source/layout.html
+++ b/source/layout.html
@@ -443,7 +443,32 @@
                         {% endif %}
 
                         {% unless hide_price %}
-                          {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                          {% assign show_strikethrough = false %}
+                          {% assign strikethrough_regular = nil %}
+                          {% assign strikethrough_sale = nil %}
+
+                          {% if theme.show_strikethrough_pricing %}
+                            {% if related_product.variable_pricing == false and related_product.original_price > related_product.default_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = related_product.original_price %}
+                              {% assign strikethrough_sale = related_product.default_price %}
+                            {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and related_product.min_original_price > related_product.min_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = related_product.min_original_price %}
+                              {% assign strikethrough_sale = related_product.min_price %}
+                            {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and related_product.max_original_price > related_product.max_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = related_product.max_original_price %}
+                              {% assign strikethrough_sale = related_product.max_price %}
+                            {% endif %}
+                          {% endif %}
+
+                          {% if show_strikethrough %}
+                            <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                            <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                          {% else %}
+                            {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                          {% endif %}
 
                           {% if related_product.price_suffix != blank %}
                             {% assign variable_price_shown = true %}
@@ -651,6 +676,7 @@
         lowInventoryMessage: "{{ t['products.low_inventory'] | replace: '"', '\"' | replace: "'", "\\'" }}",
         almostSoldOutMessage: "{{ t['products.almost_sold_out'] | replace: '"', '\"' | replace: "'", "\\'" }}",
         showBnplMessaging: {{ theme.show_bnpl_messaging }} && !themeFeatures.optOuts.includes("theme_bnpl_messaging"),
+        showStrikethroughPricing: {{ theme.show_strikethrough_pricing }},
       };
       const themeColors = {
         backgroundColor: '{{ theme.background_color }}',

--- a/source/layout.html
+++ b/source/layout.html
@@ -463,7 +463,7 @@
                       {% unless hide_price %}
                         {% if related_product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                           <div class="product-list-thumb-options-description">
-                            {{ related_product.options.size }} {{ t['products.variants'] }}
+                            {{ related_product.options.size }} {{ t['products.variants'] | downcase }}
                           </div>
                         {% endif %}
                       {% endunless %}

--- a/source/product.html
+++ b/source/product.html
@@ -10,6 +10,34 @@
     {% assign product_status = t['products.coming_soon'] %}
 {% endcase %}
 
+{% capture product_pricing %}
+  {% assign show_strikethrough = false %}
+  {% assign strikethrough_regular = nil %}
+  {% assign strikethrough_sale = nil %}
+
+  {% if theme.show_strikethrough_pricing %}
+    {% if product.variable_pricing == false and product.original_price > product.default_price %}
+      {% assign show_strikethrough = true %}
+      {% assign strikethrough_regular = product.original_price %}
+      {% assign strikethrough_sale = product.default_price %}
+    {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+      {% assign show_strikethrough = true %}
+      {% assign strikethrough_regular = product.min_original_price %}
+      {% assign strikethrough_sale = product.min_price %}
+    {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+      {% assign show_strikethrough = true %}
+      {% assign strikethrough_regular = product.max_original_price %}
+      {% assign strikethrough_sale = product.max_price %}
+    {% endif %}
+  {% endif %}
+
+  {% if show_strikethrough %}
+    <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+    <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+  {% else %}
+    {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+  {% endif %}
+{% endcapture %}
 {% assign hide_price = false %}
 {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
   {% assign hide_price = true %}
@@ -23,7 +51,7 @@
       <h1 class="page-title product-title">{{ product.name }}</h1>
       <div class="product-subtitle">
         {% unless hide_price %}
-          {{ product | product_price: theme.money_format }}
+          <span class="product-price-value">{{ product_pricing }}</span>
 
           {% if product.price_suffix != blank %}
             {% assign variable_price_shown = true %}
@@ -57,7 +85,22 @@
                   <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" id="option_group_{{ option_group.id }}" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group shrink-label" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}">
                     <option value="0" disabled="disabled" selected>{{ option_group.name }}</option>
                     {% for value in option_group.values %}
-                      <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}</option>
+                      {% assign option_status_label = '' %}
+                      {% if product.option_groups.size == 1 %}
+                        {% for option in product.options %}
+                          {% for ogv in option.option_group_values %}
+                            {% if ogv.id == value.id %}
+                              {% if option.sold_out %}
+                                {% assign option_status_label = t['products.sold_out'] | downcase %}
+                              {% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %}
+                                {% assign option_status_label = t['products.on_sale'] | downcase %}
+                              {% endif %}
+                              {% break %}
+                            {% endif %}
+                          {% endfor %}
+                        {% endfor %}
+                      {% endif %}
+                      <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}{% if option_status_label != blank %} ({{ option_status_label }}){% endif %}</option>
                     {% endfor %}
                   </select>
                   <svg aria-hidden="true" focusable="false" class="down-arrow" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M441.9 250.1l-19.8-19.8c-4.7-4.7-12.3-4.7-17 0L250 385.4V44c0-6.6-5.4-12-12-12h-28c-6.6 0-12 5.4-12 12v341.4L42.9 230.3c-4.7-4.7-12.3-4.7-17 0L6.1 250.1c-4.7 4.7-4.7 12.3 0 17l209.4 209.4c4.7 4.7 12.3 4.7 17 0l209.4-209.4c4.7-4.7 4.7-12.3 0-17z"></path></svg>
@@ -70,7 +113,7 @@
               <select class="product_option_select shrink-label" id="option" name="cart[add][id]" aria-label="{{ t['products.select_variant'] }}">
                 <option value="0" disabled="disabled" selected>{{ t['products.select_variant'] }}</option>
                 {% for option in product.options %}
-                  <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] }}){% endif %}</option>
+                  <option value="{{ option.id }}" data-price="{{ option.price }}" data-original-price="{{ option.original_price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }}{% if option.sold_out %} ({{ t['products.sold_out'] }}){% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %} ({{ t['products.on_sale'] | downcase }}){% endif %}</option>
                 {% endfor %}
               </select>
               <svg aria-hidden="true" focusable="false" class="down-arrow" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M441.9 250.1l-19.8-19.8c-4.7-4.7-12.3-4.7-17 0L250 385.4V44c0-6.6-5.4-12-12-12h-28c-6.6 0-12 5.4-12 12v341.4L42.9 230.3c-4.7-4.7-12.3-4.7-17 0L6.1 250.1c-4.7 4.7-4.7 12.3 0 17l209.4 209.4c4.7 4.7 12.3 4.7 17 0l209.4-209.4c4.7-4.7 4.7-12.3 0-17z"></path></svg>

--- a/source/product.html
+++ b/source/product.html
@@ -112,8 +112,4 @@
     </div>
   {% endfor %}
 </div>
-{% if product.description != blank %}
-  <div class="product-description">
-    {{ product.description | paragraphs }}
-  </div>
-{% endif %}
+<div class="product-description" data-bc-hook="product-description">{%- if product.description != blank %}{{ product.description | paragraphs }}{% endif -%}</div>

--- a/source/product.html
+++ b/source/product.html
@@ -151,7 +151,7 @@
 <div class="product-images {% if product.images.size > 1 %}main-carousel{% else %} single-image{% endif %}">
   {% for image in product.images %}
     <div class="carousel-cell">
-      <img src="{{ image | product_image_url | constrain: '1000'}}" alt="Image of {{ product.name | escape }}" />
+      <img src="{{ image | product_image_url | constrain: '1000'}}" alt="Image of {{ product.name | escape }}" {% if forloop.index == 1 %}fetchpriority="high"{% else %}loading="lazy"{% endif %} />
     </div>
   {% endfor %}
 </div>

--- a/source/products.html
+++ b/source/products.html
@@ -42,9 +42,36 @@
                   {% endif %}
 
                   {% unless hide_price %}
-                    <span class="price-amount">
-                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
-                    </span>
+                    {% assign show_strikethrough = false %}
+                    {% assign strikethrough_regular = nil %}
+                    {% assign strikethrough_sale = nil %}
+
+                    {% if theme.show_strikethrough_pricing %}
+                      {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.original_price %}
+                        {% assign strikethrough_sale = product.default_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.min_original_price %}
+                        {% assign strikethrough_sale = product.min_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.max_original_price %}
+                        {% assign strikethrough_sale = product.max_price %}
+                      {% endif %}
+                    {% endif %}
+
+                    {% if show_strikethrough %}
+                      <span class="price-amount">
+                        <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                        <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                      </span>
+                    {% else %}
+                      <span class="price-amount">
+                        {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      </span>
+                    {% endif %}
 
                     {% if product.price_suffix != blank %}
                       {% assign variable_price_shown = true %}

--- a/source/products.html
+++ b/source/products.html
@@ -64,7 +64,7 @@
                 {% unless hide_price %}
                   {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                     <div class="product-list-thumb-options-description">
-                      {{ product.options.size }} {{ t['products.variants'] }}
+                      {{ product.options.size }} {{ t['products.variants'] | downcase }}
                     </div>
                   {% endif %}
                 {% endunless %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -955,6 +955,25 @@
       }
     },
     {
+      "variable": "show_strikethrough_pricing",
+      "label": "Show strikethrough pricing",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the original price crossed out next to the sale price",
+      "requires": [
+        "feature:theme_strikethrough_pricing eq visible"
+      ]
+    },
+    {
+      "variable": "show_sale_label_in_product_options",
+      "label": "Show sale label in variant dropdowns",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Adds a sale indicator next to discounted variants in the dropdown"
+    },
+    {
       "variable": "lookbook_page_name",
       "label": "Lookbook Page Name",
       "section": "general",

--- a/source/settings.json
+++ b/source/settings.json
@@ -509,7 +509,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in your main navigation"
@@ -522,7 +523,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in the footer, excluding custom footer text"

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Netizen",
-  "version": "1.14.7",
+  "version": "1.15.0",
   "images": [
     {
       "variable": "logo_image",

--- a/source/stylesheets/product.css.sass
+++ b/source/stylesheets/product.css.sass
@@ -91,6 +91,11 @@
     margin: 0 0 10px
     max-width: 100%
 
+  select span, select span option
+    display: none
+    opacity: 0
+    visibility: hidden
+
   .select
     margin-bottom: 0
     position: relative

--- a/source/stylesheets/product.css.sass
+++ b/source/stylesheets/product.css.sass
@@ -135,6 +135,9 @@ button.reset-selection-button
   word-break: break-word
   width: 100%
 
+  &:empty
+    display: none
+
   @media screen and (max-width: $break-medium)
     order: 4
     margin: 0

--- a/source/stylesheets/products.css.sass
+++ b/source/stylesheets/products.css.sass
@@ -32,6 +32,7 @@
       margin: 0px 10px 40px
 
 .product-list-item
+  cursor: default
   display: block
   font-size: 0
   padding: #{"{% if theme.max_products_per_row == 3 %} 10px {% else %} 25px {% endif %}"}
@@ -39,6 +40,13 @@
   position: relative
   vertical-align: middle
   width: #{"{% if theme.max_products_per_row == 3 %} 33.33% {% elsif theme.max_products_per_row == 2 %} 50% {% else %} 100% {% endif %}"}
+
+  &:hover, &:focus
+    text-decoration: none
+
+    .product-list-item-name
+      text-decoration: underline
+      text-underline-offset: 3px
 
   @media only screen and (min-width: $break-medium) and (hover: hover), (-moz-touch-enabled: 0)
     &.rollover
@@ -78,7 +86,7 @@
     width: #{"{% if theme.max_products_per_row_mobile == 2 %} 50% {% else %} 100% {% endif %}"}
 
 .product-list-item-container
-  cursor: default
+  cursor: pointer
   position: relative
   width: 100%
 

--- a/source/stylesheets/products.css.sass
+++ b/source/stylesheets/products.css.sass
@@ -164,6 +164,12 @@
 .price-suffix
   white-space: nowrap
 
+// Strikethrough pricing styles
+.price-compare
+  text-decoration: line-through
+  opacity: 0.6
+  margin-right: 0.53em
+
 .product-list-thumb-options-description
   font-style: italic
   font-size: calc(#{"{% if theme.max_products_per_row == 3 %} 0.875rem {% else %} 1.25rem {% endif %}"} * var(--product-grid-scale, 1))

--- a/source/theme.js
+++ b/source/theme.js
@@ -1,5 +1,6 @@
 //= require_directory ./javascripts/vendor
 //= require javascripts/functions
 //= require javascripts/store
+//= require javascripts/product
 //= require javascripts/product-payment-messaging
 //= require javascripts/product-option-groups


### PR DESCRIPTION
## Summary

### Features
- **Strikethrough pricing** — Display original prices with strikethrough when items are on sale
- **Titlecase nav text transformation** — New option to apply titlecase formatting to navigation text

### Fixes
- **Product description container always in DOM** — The product description container is now always rendered (with a `data-bc-hook`) so it can be targeted by JS, and hidden via CSS `:empty` when there's no description
- **Hover cursor** — Corrected pointer cursor on hover for interactive elements

### Chores
- Lowercase label for options text in product grid
- Version bump to 1.15.0